### PR TITLE
Fix: SVG element causing apps to break.

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenoxui/core",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Core component of tenoxui",
   "author": "NOuSantx <nousantx@gmail.com>",
   "license": "MIT",

--- a/packages/core/src/lib/observer.ts
+++ b/packages/core/src/lib/observer.ts
@@ -2,7 +2,8 @@ export function scanAndApplyStyles(
   applyStylesCallback: (className: string) => void,
   htmlElement: HTMLElement
 ): void {
-  const classes = htmlElement.className.split(/\s+/)
+  const classes =
+    typeof htmlElement.className === 'string' ? htmlElement.className.split(/\s+/) : []
   classes.forEach((className) => {
     applyStylesCallback(className)
   })


### PR DESCRIPTION
For unknown reason, we can't use tenoxui class names inside SVG's class **in react/preact**, If we force to put an SVG element to the code, it will broke the react/preact apps. Even though it still works in plain HTML, you still can't  apply the tenoxui styles in it.