### PR TITLE
Fix: `className.split` isn't a function whenever dealing with XML-like elements such as SVG element

### DIFF
--- a/packages/@tenoxui-core/package.json
+++ b/packages/@tenoxui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tenoxui/core",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Core component of tenoxui",
   "author": "NOuSantx <nousantx@gmail.com>",
   "license": "MIT",

--- a/packages/@tenoxui-core/src/lib/observer.ts
+++ b/packages/@tenoxui-core/src/lib/observer.ts
@@ -1,22 +1,28 @@
 export function scanAndApplyStyles(
   applyStylesCallback: (className: string) => void,
-  htmlElement: HTMLElement
+  htmlElement: Element
 ): void {
-  const classes =
-    typeof htmlElement.className === 'string' ? htmlElement.className.split(/\s+/) : []
-  classes.forEach((className) => {
-    applyStylesCallback(className)
+  const classAttribute = htmlElement.getAttribute('class') || ''
+  const classNames = classAttribute.split(/\s+/)
+
+  classNames.forEach((className) => {
+    if (className.trim()) {
+      applyStylesCallback(className)
+    }
   })
 }
 
 export function setupClassObserver(
   applyStylesCallback: (className: string) => void,
-  htmlElement: HTMLElement
+  htmlElement: Element
 ): void {
   const observer = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
       if (mutation.attributeName === 'class') {
-        htmlElement.style.cssText = ''
+        if (htmlElement instanceof HTMLElement) {
+          htmlElement.style.cssText = ''
+        }
+
         scanAndApplyStyles(applyStylesCallback, htmlElement)
       }
     })


### PR DESCRIPTION
- Release: `tenoxui/core` v1.3.8